### PR TITLE
Fix - Parameterize config to accept connection names.

### DIFF
--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -52,11 +52,11 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
     protected function pushToCloudTasks($queue, $payload, $delay = 0, $attempts = 0)
     {
         $queue = $this->getQueue($queue);
-        $queueName = $this->client->queueName(Config::project(), Config::location(), $queue);
+        $queueName = $this->client->queueName(Config::project($this->connectionName), Config::location($this->connectionName), $queue);
         $availableAt = $this->availableAt($delay);
 
         $httpRequest = $this->createHttpRequest();
-        $httpRequest->setUrl(Config::handler());
+        $httpRequest->setUrl(Config::handler($this->connectionName));
         $httpRequest->setHttpMethod(HttpMethod::POST);
         $httpRequest->setBody($payload);
 
@@ -64,7 +64,7 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         $task->setHttpRequest($httpRequest);
 
         $token = new OidcToken;
-        $token->setServiceAccountEmail(Config::serviceAccountEmail());
+        $token->setServiceAccountEmail(Config::serviceAccountEmail($this->connectionName));
         $httpRequest->setOidcToken($token);
 
         if ($availableAt > time()) {

--- a/src/Config.php
+++ b/src/Config.php
@@ -6,29 +6,29 @@ use Error;
 
 class Config
 {
-    public static function credentials()
+    public static function credentials($connection = 'cloudtasks')
     {
-        return config('queue.connections.cloudtasks.credentials');
+        return config("queue.connections.{$connection}.credentials");
     }
 
-    public static function project()
+    public static function project($connection = 'cloudtasks')
     {
-        return config('queue.connections.cloudtasks.project');
+        return config("queue.connections.{$connection}.project");
     }
 
-    public static function location()
+    public static function location($connection = 'cloudtasks')
     {
-        return config('queue.connections.cloudtasks.location');
+        return config("queue.connections.{$connection}.location");
     }
 
-    public static function handler()
+    public static function handler($connection = 'cloudtasks')
     {
-        return config('queue.connections.cloudtasks.handler');
+        return config("queue.connections.{$connection}.handler");
     }
 
-    public static function serviceAccountEmail()
+    public static function serviceAccountEmail($connection = 'cloudtasks')
     {
-        return config('queue.connections.cloudtasks.service_account_email');
+        return config("queue.connections.{$connection}.service_account_email");
     }
 
     public static function validate(array $config)

--- a/src/Config.php
+++ b/src/Config.php
@@ -6,31 +6,6 @@ use Error;
 
 class Config
 {
-    public static function credentials($connection = 'cloudtasks')
-    {
-        return config("queue.connections.{$connection}.credentials");
-    }
-
-    public static function project($connection = 'cloudtasks')
-    {
-        return config("queue.connections.{$connection}.project");
-    }
-
-    public static function location($connection = 'cloudtasks')
-    {
-        return config("queue.connections.{$connection}.location");
-    }
-
-    public static function handler($connection = 'cloudtasks')
-    {
-        return config("queue.connections.{$connection}.handler");
-    }
-
-    public static function serviceAccountEmail($connection = 'cloudtasks')
-    {
-        return config("queue.connections.{$connection}.service_account_email");
-    }
-
     public static function validate(array $config)
     {
         if (empty($config['project'])) {

--- a/src/TaskHandler.php
+++ b/src/TaskHandler.php
@@ -29,7 +29,7 @@ class TaskHandler
         $task = $task ?: $this->captureTask();
 
         $command = unserialize($task['data']['command']);
-        $connection = $command->connection ?? 'cloudtasks';
+        $connection = $command->connection ?? config('queue.default');
 
         $this->authorizeRequest($connection);
 

--- a/tests/TaskHandlerTest.php
+++ b/tests/TaskHandlerTest.php
@@ -77,7 +77,7 @@ class TaskHandlerTest extends TestCase
         $this->expectException(CloudTasksException::class);
         $this->expectExceptionMessage('Missing [Authorization] header');
 
-        $this->handler->handle();
+        $this->handler->handle($this->simpleJob());
     }
 
     /** @test */

--- a/tests/TaskHandlerTest.php
+++ b/tests/TaskHandlerTest.php
@@ -165,7 +165,7 @@ class TaskHandlerTest extends TestCase
         }
 
         $this->assertDatabaseHas('failed_jobs', [
-            'connection' => 'cloudtasks',
+            'connection' => 'my-cloudtasks-connection',
             'queue' => 'my-queue',
             'payload' => rtrim($this->failingJobPayload()),
         ]);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -59,8 +59,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
         }
 
         $app['config']->set('cache.default', 'file');
-        $app['config']->set('queue.default', 'cloudtasks');
-        $app['config']->set('queue.connections.cloudtasks', [
+        $app['config']->set('queue.default', 'my-cloudtasks-connection');
+        $app['config']->set('queue.connections.my-cloudtasks-connection', [
             'driver' => 'cloudtasks',
             'queue' => 'test-queue',
             'project' => 'test-project',
@@ -72,6 +72,6 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function setConfigValue($key, $value)
     {
-        $this->app['config']->set('queue.connections.cloudtasks.' . $key, $value);
+        $this->app['config']->set('queue.connections.my-cloudtasks-connection.' . $key, $value);
     }
 }


### PR DESCRIPTION
Closes: https://github.com/stackkit/laravel-google-cloud-tasks-queue/issues/22

@marickvantuil - The one thing I could use your input on is how to update the calls to `Config` in `TaskHandler`. I've made a first attempt at it and tested it locally with a payload and it checks out!