### PR TITLE
Fix cache expiration condition

### DIFF
--- a/src/OpenIdVerificator.php
+++ b/src/OpenIdVerificator.php
@@ -50,9 +50,9 @@ class OpenIdVerificator
 
     public function getPublicKey($kid = null)
     {
-        if (Cache::has(self::V3_CERTS)) {
-            $v3Certs = Cache::get(self::V3_CERTS);
-        } else {
+        $v3Certs = Cache::get(self::V3_CERTS);
+        
+        if (is_null($v3Certs)) {
             $v3Certs = $this->getFreshCertificates();
             Cache::put(self::V3_CERTS, $v3Certs, Carbon::now()->addSeconds($this->maxAge[self::URL_OPENID_CONFIG]));
         }


### PR DESCRIPTION
I suggest better management of cache expiration for [OpenIdVerificator getPublicKey](https://github.com/stackkit/laravel-google-cloud-tasks-queue/blob/453d9a75d149a04e2a749a0de6f9b0e5dbe4e7d6/src/OpenIdVerificator.php#L51) method.
See discuss https://github.com/stackkit/laravel-google-cloud-tasks-queue/discussions/29#discussioncomment-1205080