### PR TITLE
Support encryption, avoid double __unserialize call

### DIFF
--- a/src/CloudTasksJob.php
+++ b/src/CloudTasksJob.php
@@ -24,9 +24,9 @@ class CloudTasksJob extends LaravelJob implements JobContract
         $this->job = $job;
         $this->container = Container::getInstance();
         $this->cloudTasksQueue = $cloudTasksQueue;
-        /** @var \stdClass $command */
-        $command = unserialize($job['data']['command']);
-        $this->queue = $command->queue;
+        
+        $command = TaskHandler::getCommandProperties($job['data']['command']);
+        $this->queue = $command['queue'] ?? config('queue.connections.' .config('queue.default') . '.queue');
     }
 
     public function getJobId(): string

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -7,6 +7,7 @@ namespace Tests;
 use Google\Cloud\Tasks\V2\HttpMethod;
 use Google\Cloud\Tasks\V2\Task;
 use Stackkit\LaravelGoogleCloudTasksQueue\CloudTasksApi;
+use Stackkit\LaravelGoogleCloudTasksQueue\TaskHandler;
 use Tests\Support\FailingJob;
 use Tests\Support\SimpleJob;
 
@@ -137,19 +138,19 @@ class QueueTest extends TestCase
         // Assert
         CloudTasksApi::assertTaskCreated(function (Task $task, string $queueName): bool {
             $decoded = json_decode($task->getHttpRequest()->getBody(), true);
-            $command = unserialize($decoded['data']['command']);
+            $command = TaskHandler::getCommandProperties($decoded['data']['command']);
 
             return $decoded['displayName'] === SimpleJob::class
-                && $command->queue === null
+                && $command['queue'] === null
                 && $queueName === 'projects/my-test-project/locations/europe-west6/queues/barbequeue';
         });
 
         CloudTasksApi::assertTaskCreated(function (Task $task, string $queueName): bool {
             $decoded = json_decode($task->getHttpRequest()->getBody(), true);
-            $command = unserialize($decoded['data']['command']);
+            $command = TaskHandler::getCommandProperties($decoded['data']['command']);
 
             return $decoded['displayName'] === FailingJob::class
-                && $command->queue === 'my-special-queue'
+                && $command['queue'] === 'my-special-queue'
                 && $queueName === 'projects/my-test-project/locations/europe-west6/queues/my-special-queue';
         });
     }

--- a/tests/Support/EncryptedJob.php
+++ b/tests/Support/EncryptedJob.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Support;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeEncrypted;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class EncryptedJob implements ShouldQueue, ShouldBeEncrypted
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function handle()
+    {
+        logger('EncryptedJob:success');
+    }
+}


### PR DESCRIPTION
Laravel uses the magic method `__unserialize()` in the `SerializesModels` trait, which does a bunch of work to rehydrate models attached to jobs. This gets called every time the job is unserialized. The addition of an `unserialize()` call in the constructor to get the `queue` property causes it to run twice because of the original call to `unserialize()` is in `\Illuminate\Queue\CallQueuedHandler->getCommand()`.

`CallQueuedHandler->getCommand()` also implements support for encrypted command payloads.

This change brings over the encryption support logic from `CallQueuedHandler->getCommand()` and passed `['allowed_classes' => false]` to the `unserialize()` call. This will make it _not_ hydrate to the original job object, but instead to an instance of `__PHP_Incomplete_Class` avoiding the unnecessary call to `__unserialize()` with this `unserialize()` call. We then cast to an `(array)` to access the `queue` property without issue.