### PR TITLE
set a name for the cloud task based on display name and UUID

### DIFF
--- a/src/CloudTasksApiFake.php
+++ b/src/CloudTasksApiFake.php
@@ -30,8 +30,6 @@ class CloudTasksApiFake implements CloudTasksApiContract
 
     public function createTask(string $queueName, Task $task): Task
     {
-        $task->setName(Str::uuid()->toString());
-
         $this->createdTasks[] = compact('queueName', 'task');
 
         return $task;
@@ -56,24 +54,16 @@ class CloudTasksApiFake implements CloudTasksApiContract
 
     public function assertTaskDeleted(string $taskName): void
     {
-        $taskUuids = array_map(function ($fullTaskName) {
-            return Arr::last(explode('/', $fullTaskName));
-        }, $this->deletedTasks);
-
         Assert::assertTrue(
-            in_array($taskName, $taskUuids),
+            in_array($taskName, $this->deletedTasks),
             'The task [' . $taskName . '] should have been deleted but it is not.'
         );
     }
 
     public function assertTaskNotDeleted(string $taskName): void
     {
-        $taskUuids = array_map(function ($fullTaskName) {
-            return Arr::last(explode('/', $fullTaskName));
-        }, $this->deletedTasks);
-
         Assert::assertTrue(
-            ! in_array($taskName, $taskUuids),
+            ! in_array($taskName, $this->deletedTasks),
             'The task [' . $taskName . '] should not have been deleted but it was.'
         );
     }

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -152,7 +152,7 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         $httpRequest->setBody($payload);
 
         $task = $this->createTask();
-        $task->setName($this->taskName($uuid, $displayName));
+        $task->setName($this->taskName($queueName, $uuid, $displayName));
         $task->setHttpRequest($httpRequest);
 
         // The deadline for requests sent to the app. If the app does not respond by
@@ -178,9 +178,14 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         return $uuid;
     }
 
-    private function taskName(string $uuid, string $displayName) {
+    private function taskName(string $queueName, string $uuid, string $displayName) {
+        $config = $this->config;
+        $projectId = $config['project'];
+        $location = $config['location'];
+        $queueId = $queueName;
+        // projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID
         $displayName = str_replace("\\", "-", $displayName);
-        return sprintf('%s-%s', $uuid, $displayName);
+        return sprintf('projects/%s/locations/%s/queues/%s/tasks/%s-%s', $projectId, $location, $queueId, $uuid, $displayName);
     }
 
     private function extractPayload(string $payload): array

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -153,7 +153,7 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         $httpRequest->setBody($payload);
 
         $task = $this->createTask();
-        $task->setName($this->taskName($queueName, $uuid, $displayName));
+        $task->setName($this->taskName($queue, $uuid, $displayName));
         $task->setHttpRequest($httpRequest);
 
         // The deadline for requests sent to the app. If the app does not respond by
@@ -184,6 +184,7 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         $projectId = $config['project'];
         $location = $config['location'];
         $queueId = $queueName;
+        // projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID
         // projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID
         $displayName = str_replace("\\", "-", $displayName);
         $taskName = sprintf('projects/%s/locations/%s/queues/%s/tasks/%s-%s', $projectId, $location, $queueId, $uuid, $displayName);

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -11,6 +11,7 @@ use Google\Protobuf\Duration;
 use Google\Protobuf\Timestamp;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Queue\Queue as LaravelQueue;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Stackkit\LaravelGoogleCloudTasksQueue\Events\TaskCreated;
 use function Safe\json_decode;
@@ -185,7 +186,9 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         $queueId = $queueName;
         // projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID
         $displayName = str_replace("\\", "-", $displayName);
-        return sprintf('projects/%s/locations/%s/queues/%s/tasks/%s-%s', $projectId, $location, $queueId, $uuid, $displayName);
+        $taskName = sprintf('projects/%s/locations/%s/queues/%s/tasks/%s-%s', $projectId, $location, $queueId, $uuid, $displayName);
+        Log::info('Task name '. $taskName);
+        return $taskName;
     }
 
     private function extractPayload(string $payload): array

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -11,7 +11,6 @@ use Google\Protobuf\Duration;
 use Google\Protobuf\Timestamp;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Queue\Queue as LaravelQueue;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Stackkit\LaravelGoogleCloudTasksQueue\Events\TaskCreated;
 use function Safe\json_decode;
@@ -140,20 +139,22 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         $httpRequest->setUrl($this->getHandler());
         $httpRequest->setHttpMethod(HttpMethod::POST);
 
+        $payload = json_decode($payload, true);
+
         // Laravel 7+ jobs have a uuid, but Laravel 6 doesn't have it.
         // Since we are using and expecting the uuid in some places
         // we will add it manually here if it's not present yet.
-        [$payload, $uuid, $displayName] = $this->extractPayload($payload);
+        $payload = $this->withUuid($payload);
 
         // Since 3.x tasks are released back onto the queue after an exception has
         // been thrown. This means we lose the native [X-CloudTasks-TaskRetryCount] header
         // value and need to manually set and update the number of times a task has been attempted.
         $payload = $this->withAttempts($payload);
 
-        $httpRequest->setBody($payload);
+        $httpRequest->setBody(json_encode($payload));
 
         $task = $this->createTask();
-        $task->setName($this->taskName($queue, $uuid, $displayName));
+        $task->setName($this->taskName($queue, $payload));
         $task->setHttpRequest($httpRequest);
 
         // The deadline for requests sent to the app. If the app does not respond by
@@ -174,51 +175,39 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
 
         $createdTask = CloudTasksApi::createTask($queueName, $task);
 
-        event((new TaskCreated)->queue($queue)->task($createdTask));
+        event((new TaskCreated)->queue($queue)->task($task));
 
-        return $uuid;
+        return $payload['uuid'];
     }
 
-    private function taskName(string $queueName, string $uuid, string $displayName) {
-        $config = $this->config;
-        $projectId = $config['project'];
-        $location = $config['location'];
-        $queueId = $queueName;
-        // projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID
-        // projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID
-        $displayName = str_replace("\\", "-", $displayName);
-        $taskName = sprintf('projects/%s/locations/%s/queues/%s/tasks/%s-%s', $projectId, $location, $queueId, $uuid, $displayName);
-        print ($taskName);
-        print ($taskName);
-        return $taskName;
-    }
-
-    private function extractPayload(string $payload): array
+    private function withUuid(array $payload): array
     {
-        /** @var array $decoded */
-        $decoded = json_decode($payload, true);
-
-        if (!isset($decoded['uuid'])) {
-            $decoded['uuid'] = (string) Str::uuid();
+        if (!isset($payload['uuid'])) {
+            $payload['uuid'] = (string) Str::uuid();
         }
 
-        return [
-            json_encode($decoded),
-            $decoded['uuid'],
-            $decoded['displayName']
-        ];
+        return $payload;
     }
 
-    private function withAttempts(string $payload): string
+    private function taskName(string $queueName, array $payload): string
     {
-        /** @var array $decoded */
-        $decoded = json_decode($payload, true);
+        $displayName = str_replace("\\", '-', $payload['displayName']);
 
-        if (!isset($decoded['internal']['attempts'])) {
-            $decoded['internal']['attempts'] = 0;
+        return CloudTasksClient::taskName(
+            $this->config['project'],
+            $this->config['location'],
+            $queueName,
+            $displayName . '-' . $payload['uuid']
+        );
+    }
+
+    private function withAttempts(array $payload): array
+    {
+        if (!isset($payload['internal']['attempts'])) {
+            $payload['internal']['attempts'] = 0;
         }
 
-        return json_encode($decoded);
+        return $payload;
     }
 
     /**

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -188,7 +188,8 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         // projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID
         $displayName = str_replace("\\", "-", $displayName);
         $taskName = sprintf('projects/%s/locations/%s/queues/%s/tasks/%s-%s', $projectId, $location, $queueId, $uuid, $displayName);
-        Log::info('Task name '. $taskName);
+        print ($taskName);
+        print ($taskName);
         return $taskName;
     }
 

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -478,4 +478,23 @@ class QueueTest extends TestCase
         Log::assertLogged('UserJob:John');
         CloudTasksApi::assertTaskNotDeleted($job->task->getName());
     }
+
+    /**
+     * @test
+     */
+    public function it_adds_a_task_name_based_on_the_display_name()
+    {
+        // Arrange
+        CloudTasksApi::fake();
+
+        // Act
+        $this->dispatch((new SimpleJob()));
+
+        // Assert
+        CloudTasksApi::assertTaskCreated(function (Task $task, string $queueName): bool {
+            $uuid = \Safe\json_decode($task->getHttpRequest()->getBody(), true)['uuid'];
+
+            return $task->getName() === 'projects/my-test-project/locations/europe-west6/queues/barbequeue/tasks/Tests-Support-SimpleJob-' . $uuid;
+        });
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -133,7 +133,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
             $payloadAsArray = json_decode($payload, true);
             $task = $event->task;
 
-            request()->headers->set('X-Cloudtasks-Taskname', $task->getName());
+            [,,,,,,,$taskName] = explode('/', $task->getName());
+            request()->headers->set('X-Cloudtasks-Taskname', $taskName);
         });
 
         dispatch($job);


### PR DESCRIPTION
Gives a more readable name in the Google Tasks console and API.