### PR TITLE
upgrade to phpseclib 3.0 to match google's upgrade of phpseclib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "ext-json": "*",
-        "phpseclib/phpseclib": "~2.0",
+        "phpseclib/phpseclib": "~3.0",
         "google/cloud-tasks": "^1.10",
         "thecodingmachine/safe": "^1.0|^2.0"
     },


### PR DESCRIPTION
Google have updated phpseclib in their API client to 3.0. This allows consumers of this library to keep packages up to date. 