### PR TITLE
Add optional signed_audience flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please check the [Laravel support policy](https://laravel.com/docs/master/releas
       'handler' => env('STACKKIT_CLOUD_TASKS_HANDLER', ''),
       'queue' => env('STACKKIT_CLOUD_TASKS_QUEUE', 'default'),
       'service_account_email' => env('STACKKIT_CLOUD_TASKS_SERVICE_EMAIL', ''),
-      'signed_audience' => env('STACKKIT_CLOUD_TASKS_SIGNED_AUDIENCE', false),
+      'signed_audience' => env('STACKKIT_CLOUD_TASKS_SIGNED_AUDIENCE', true),
       // Optional: The deadline in seconds for requests sent to the worker. If the worker
       // does not respond by this deadline then the request is cancelled and the attempt
       // is marked as a DEADLINE_EXCEEDED failure.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Please check the table below on what the values mean and what their value should
 | `STACKKIT_CLOUD_TASKS_QUEUE`         | The default queue a job will be added to                                                                                                                                                  |`emails`
 | `STACKKIT_CLOUD_TASKS_SERVICE_EMAIL` | The email address of the service account. Important, it should have the correct roles. See the section below which roles.                                                        |`my-service-account@appspot.gserviceaccount.com`
 | `STACKKIT_CLOUD_TASKS_HANDLER` (optional) | The URL that Cloud Tasks will call to process a job. This should be the URL to your Laravel app. By default we will use the URL that dispatched the job. |`https://<your website>.com`
-| `STACKKIT_CLOUD_TASKS_SIGNED_AUDIENCE` (optional) | True or false depending if you want extra security by signing the audience of your tasks. May misbehave in certain Cloud Run setups. Defaults to false. | `false`
+| `STACKKIT_CLOUD_TASKS_SIGNED_AUDIENCE` (optional) | True or false depending if you want extra security by signing the audience of your tasks. May misbehave in certain Cloud Run setups. Defaults to true.   | `true`
 </details>
 <details>
 <summary>

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Please check the [Laravel support policy](https://laravel.com/docs/master/releas
       'handler' => env('STACKKIT_CLOUD_TASKS_HANDLER', ''),
       'queue' => env('STACKKIT_CLOUD_TASKS_QUEUE', 'default'),
       'service_account_email' => env('STACKKIT_CLOUD_TASKS_SERVICE_EMAIL', ''),
+      'signed_audience' => env('STACKKIT_CLOUD_TASKS_SIGNED_AUDIENCE', false),
       // Optional: The deadline in seconds for requests sent to the worker. If the worker
       // does not respond by this deadline then the request is cancelled and the attempt
       // is marked as a DEADLINE_EXCEEDED failure.
@@ -70,6 +71,7 @@ Please check the table below on what the values mean and what their value should
 | `STACKKIT_CLOUD_TASKS_QUEUE`         | The default queue a job will be added to                                                                                                                                                  |`emails`
 | `STACKKIT_CLOUD_TASKS_SERVICE_EMAIL` | The email address of the service account. Important, it should have the correct roles. See the section below which roles.                                                        |`my-service-account@appspot.gserviceaccount.com`
 | `STACKKIT_CLOUD_TASKS_HANDLER` (optional) | The URL that Cloud Tasks will call to process a job. This should be the URL to your Laravel app. By default we will use the URL that dispatched the job. |`https://<your website>.com`
+| `STACKKIT_CLOUD_TASKS_SIGNED_AUDIENCE` (optional) | True or false depending if you want extra security by signing the audience of your tasks. May misbehave in certain Cloud Run setups. Defaults to false. | `false`
 </details>
 <details>
 <summary>

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -95,7 +95,7 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        $delay = ! empty($options['delay']) ? $options['delay'] : 0;
+        $delay = !empty($options['delay']) ? $options['delay'] : 0;
 
         $this->pushToCloudTasks($queue, $payload, $delay);
     }
@@ -270,7 +270,7 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         return Config::getHandler($this->config['handler']);
     }
 
-    public function getAudience(): string
+    public function getAudience(): ?string
     {
         return Config::getAudience($this->config);
     }

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -167,7 +167,9 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
 
         $token = new OidcToken;
         $token->setServiceAccountEmail($this->config['service_account_email']);
-        if ($audience = $this->getAudience()) $token->setAudience($audience);
+        if ($audience = $this->getAudience()) {
+            $token->setAudience($audience);
+        }
         $httpRequest->setOidcToken($token);
 
         if ($availableAt > time()) {

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -168,7 +168,7 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
 
         $token = new OidcToken;
         $token->setServiceAccountEmail($this->config['service_account_email']);
-        $token->setAudience($this->getAudience());
+        if ($audience = $this->getAudience()) $token->setAudience($audience);
         $httpRequest->setOidcToken($token);
 
         if ($availableAt > time()) {

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -95,7 +95,7 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
      */
     public function pushRaw($payload, $queue = null, array $options = [])
     {
-        $delay = !empty($options['delay']) ? $options['delay'] : 0;
+        $delay = ! empty($options['delay']) ? $options['delay'] : 0;
 
         $this->pushToCloudTasks($queue, $payload, $delay);
     }

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -132,13 +132,12 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
      */
     protected function pushToCloudTasks($queue, $payload, $delay = 0)
     {
-        $handleTargetUrl = $this->getHandler();
         $queue = $this->getQueue($queue);
         $queueName = $this->client->queueName($this->config['project'], $this->config['location'], $queue);
         $availableAt = $this->availableAt($delay);
 
         $httpRequest = $this->createHttpRequest();
-        $httpRequest->setUrl($handleTargetUrl);
+        $httpRequest->setUrl($this->getHandler());
         $httpRequest->setHttpMethod(HttpMethod::POST);
 
         $payload = json_decode($payload, true);

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -192,7 +192,7 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
 
     private function taskName(string $queueName, array $payload): string
     {
-        $displayName = str_replace("\\", '-', $payload['displayName']);
+        $displayName = $this->sanitizeTaskName($payload['displayName']);
 
         return CloudTasksClient::taskName(
             $this->config['project'],
@@ -200,6 +200,17 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
             $queueName,
             $displayName . '-' . $payload['uuid'] . '-' . Carbon::now()->getTimestamp(),
         );
+    }
+
+    private function sanitizeTaskName(string $taskName)
+    {
+        // Remove all characters that are not -, letters, numbers, or whitespace
+        $sanitizedName = preg_replace('![^-\pL\pN\s]+!u', '-', $taskName);
+
+        // Replace all separator characters and whitespace by a -
+        $sanitizedName = preg_replace('![-\s]+!u', '-', $sanitizedName);
+
+        return trim($sanitizedName, '-');
     }
 
     private function withAttempts(array $payload): array

--- a/src/Config.php
+++ b/src/Config.php
@@ -89,7 +89,7 @@ class Config
      */
     public static function getAudience(array $config): ?string
     {
-        return $config['signed_audience'] ?? false
+        return $config['signed_audience'] ?? true
             ? hash_hmac('sha256', self::getHandler($config['handler']), config('app.key'))
             : null;
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -84,7 +84,8 @@ class Config
     }
 
     /**
-     * @param string $handler
+     * @param array $config
+     * @return string|null The audience as an hash or null if not needed
      */
     public static function getAudience(array $config): ?string
     {

--- a/src/Config.php
+++ b/src/Config.php
@@ -82,4 +82,16 @@ class Config
             );
         }
     }
+
+    /**
+     * @param string $handler
+     */
+    public static function getAudience(array $config): string
+    {
+        $handler = self::getHandler($config['handler']);
+
+        return $config['signed_audience'] ?? false
+            ? hash_hmac('sha256', $handler, config('app.key'))
+            : $handler;
+    }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -88,10 +88,8 @@ class Config
      */
     public static function getAudience(array $config): string
     {
-        $handler = self::getHandler($config['handler']);
-
         return $config['signed_audience'] ?? false
-            ? hash_hmac('sha256', $handler, config('app.key'))
-            : $handler;
+            ? hash_hmac('sha256', self::getHandler($config['handler']), config('app.key'))
+            : null;
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -86,7 +86,7 @@ class Config
     /**
      * @param string $handler
      */
-    public static function getAudience(array $config): string
+    public static function getAudience(array $config): ?string
     {
         return $config['signed_audience'] ?? false
             ? hash_hmac('sha256', self::getHandler($config['handler']), config('app.key'))

--- a/src/OpenIdVerificatorConcrete.php
+++ b/src/OpenIdVerificatorConcrete.php
@@ -18,7 +18,7 @@ class OpenIdVerificatorConcrete extends Facade
         (new AccessToken())->verify(
             $token,
             [
-                'audience' => hash_hmac('sha256', app('queue')->getHandler(), config('app.key')),
+                'audience' => Config::getAudience($config),
                 'throwException' => true,
             ]
         );

--- a/src/OpenIdVerificatorFake.php
+++ b/src/OpenIdVerificatorFake.php
@@ -17,7 +17,7 @@ class OpenIdVerificatorFake
         (new AccessToken())->verify(
             $token,
             [
-                'audience' => hash_hmac('sha256', app('queue')->getHandler(), config('app.key')),
+                'audience' => Config::getAudience($config),
                 'throwException' => true,
                 'certsLocation' => __DIR__ . '/../tests/Support/self-signed-public-key-as-jwk.json',
             ]

--- a/src/TaskHandler.php
+++ b/src/TaskHandler.php
@@ -86,7 +86,6 @@ class TaskHandler
         try {
             $validator->validate();
         } catch (ValidationException $e) {
-            report($e);
             if (config('app.debug')) {
                 throw $e;
             } else {
@@ -136,7 +135,6 @@ class TaskHandler
             $apiTask = CloudTasksApi::getTask($fullTaskName);
         } catch (ApiException $e) {
             if (in_array($e->getStatus(), ['NOT_FOUND', 'PRECONDITION_FAILED'])) {
-                report($e);
                 abort(404);
             }
 

--- a/src/TaskHandler.php
+++ b/src/TaskHandler.php
@@ -86,6 +86,7 @@ class TaskHandler
         try {
             $validator->validate();
         } catch (ValidationException $e) {
+            report($e);
             if (config('app.debug')) {
                 throw $e;
             } else {
@@ -135,6 +136,7 @@ class TaskHandler
             $apiTask = CloudTasksApi::getTask($fullTaskName);
         } catch (ApiException $e) {
             if (in_array($e->getStatus(), ['NOT_FOUND', 'PRECONDITION_FAILED'])) {
+                report($e);
                 abort(404);
             }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -103,6 +103,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
             'location' => 'europe-west6',
             'handler' => env('CLOUD_TASKS_HANDLER', 'https://docker.for.mac.localhost:8080'),
             'service_account_email' => 'info@stackkit.io',
+            'signed_audience' => true,
         ]);
         $app['config']->set('queue.failed.driver', 'database-uuids');
         $app['config']->set('queue.failed.database', 'testbench');


### PR DESCRIPTION
Fix for #113 

This fixes issues with some Cloud Run setups where providing the audience to the OidcToken causes the queue runners to receive 401 when trying to POST to Cloud Run instances.