### PR TITLE
Audience signing fix

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -89,8 +89,10 @@ class Config
      */
     public static function getAudience(array $config): ?string
     {
+        $handler = self::getHandler($config['handler']);
+
         return $config['signed_audience'] ?? true
-            ? hash_hmac('sha256', self::getHandler($config['handler']), config('app.key'))
-            : null;
+            ? hash_hmac('sha256', $handler, config('app.key'))
+            : $handler;
     }
 }


### PR DESCRIPTION
This pull request fixes the following issue.

"From the documentation, the audience should not be a hash. It should be an URL."

https://github.com/stackkit/laravel-google-cloud-tasks-queue/issues/113

