### PR TITLE
Support ShouldBeUnique and uniqueId for task de-duplication.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "ext-json": "*",
-        "phpseclib/phpseclib": "~2.0",
+        "phpseclib/phpseclib": "~3.0",
         "google/cloud-tasks": "^1.10",
         "thecodingmachine/safe": "^1.0|^2.0"
     },

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -298,7 +298,7 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         } else {
             $uniqueId = $displayName . '-' . $payloadArray['uuid'] . '-' . Carbon::now()->getTimestamp();
         }
-        $payload["uniqueId"] = $uniqueId;
-        return $payload;
+        $payloadArray["uniqueId"] = $uniqueId;
+        return $payloadArray;
     }
 }


### PR DESCRIPTION
According to Google:

```
If a task's ID is identical to that of an existing task or a task that was deleted or executed recently then the call will fail with ALREADY_EXISTS
```