### PR TITLE
feat: Support path in STACKKIT_CLOUD_TASKS_HANDLER

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -63,18 +63,13 @@ class Config
                 ));
             }
 
-            // Versions 1.x and 2.x required the full path (e.g. my-app.com/handle-task). In 3.x and beyond
-            // it is no longer necessary to also include the path and simply setting the handler
-            // URL is enough. If someone upgrades and forgets we will warn them here.
-            if (!empty($parse['path'])) {
-                throw new Exception(
-                    'Unable to push task to Cloud Tasks because the task handler URL (' . $handler . ') is not ' .
-                    'compatible. To fix this, please remove \'' . $parse['path'] . '\' from the URL, ' .
-                    'or copy from here: STACKKIT_CLOUD_TASKS_HANDLER=' . $parse['scheme'] . '://' . $parse['host']
-                );
+            $trimmedHandlerUrl = rtrim($handler, '/');
+
+            if (!str_ends_with($trimmedHandlerUrl, '/handle-task')) {
+                return $trimmedHandlerUrl . '/handle-task';
             }
 
-            return $handler . '/handle-task';
+            return $trimmedHandlerUrl;
         } catch (UrlException $e) {
             throw new Exception(
                 'Unable to push task to Cloud Tasks because the task handler URL (' . $handler . ') is ' .

--- a/src/Config.php
+++ b/src/Config.php
@@ -66,7 +66,7 @@ class Config
             $trimmedHandlerUrl = rtrim($handler, '/');
 
             if (!str_ends_with($trimmedHandlerUrl, '/handle-task')) {
-                return $trimmedHandlerUrl . '/handle-task';
+                return "$trimmedHandlerUrl/handle-task";
             }
 
             return $trimmedHandlerUrl;

--- a/tests/ConfigHandlerTest.php
+++ b/tests/ConfigHandlerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tests;
+
+use Stackkit\LaravelGoogleCloudTasksQueue\Config;
+
+class ConfigHandlerTest extends TestCase
+{
+    /**
+     * @dataProvider handlerDataProvider
+     */
+    public function test_it_allows_a_handler_url_to_contain_path(string $handler, string $expectedHandler): void
+    {
+        self::assertSame($expectedHandler, Config::getHandler($handler));
+    }
+
+    public function handlerDataProvider(): array
+    {
+        return [
+            ['https://example.com', 'https://example.com/handle-task'],
+            ['https://example.com/my/path', 'https://example.com/my/path/handle-task'],
+            ['https://example.com/trailing/slashes//', 'https://example.com/trailing/slashes/handle-task'],
+            ['https://example.com/handle-task', 'https://example.com/handle-task'],
+            ['https://example.com/handle-task/', 'https://example.com/handle-task'],
+        ];
+    }
+}

--- a/tests/ConfigHandlerTest.php
+++ b/tests/ConfigHandlerTest.php
@@ -4,7 +4,7 @@ namespace Tests;
 
 use Stackkit\LaravelGoogleCloudTasksQueue\Config;
 
-class ConfigHandlerTest extends TestCase
+class ConfigHandlerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider handlerDataProvider


### PR DESCRIPTION
This adds support for the STACKKIT_CLOUD_TASKS_HANDLER url to handle subpaths

Sometimes an application is deployed on a URL that is not the root domain which we do.

This should be backwards compatible as it supports STACKKIT_CLOUD_TASKS_HANDLER having the `handle-task` suffix already, or if it doesn't have it it'll add it.

Closes #119 