### PR TITLE
Connection from task is not properly used when handling incoming task

### DIFF
--- a/src/TaskHandler.php
+++ b/src/TaskHandler.php
@@ -13,7 +13,6 @@ use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
 use Safe\Exceptions\JsonException;
-use stdClass;
 use UnexpectedValueException;
 use function Safe\json_decode;
 
@@ -98,11 +97,8 @@ class TaskHandler
 
     private function loadQueueConnectionConfiguration(array $task): void
     {
-        /**
-         * @var stdClass $command
-         */
         $command = self::getCommandProperties($task['data']['command']);
-        $connection = $command->connection ?? config('queue.default');
+        $connection = $command['connection'] ?? config('queue.default');
         $baseConfig = config('queue.connections.' . $connection);
         $config = (new CloudTasksConnector())->connect($baseConfig)->config;
 

--- a/tests/TaskHandlerTest.php
+++ b/tests/TaskHandlerTest.php
@@ -225,6 +225,26 @@ class TaskHandlerTest extends TestCase
     /**
      * @test
      */
+    public function it_can_run_a_task_using_the_task_connection()
+    {
+        // Arrange
+        OpenIdVerificator::fake();
+        Log::swap(new LogFake());
+        Event::fake([JobProcessing::class, JobProcessed::class]);
+        $this->app['config']->set('queue.default', 'non-existing-connection');
+
+        // Act
+        $job = new SimpleJob();
+        $job->connection = 'my-cloudtasks-connection';
+        $this->dispatch($job)->runWithoutExceptionHandler();
+
+        // Assert
+        Log::assertLogged('SimpleJob:success');
+    }
+
+    /**
+     * @test
+     */
     public function after_max_attempts_it_will_log_to_failed_table()
     {
         // Arrange


### PR DESCRIPTION
I noticed that when an incoming task is handled, the "connection" attribute of the command is not properly fetched. There is code for it, it [used to work](https://github.com/stackkit/laravel-google-cloud-tasks-queue/commit/1338a0b45306dc7e6d9bd570ee9f9977f855026e#diff-369ea07f0ba3fd0b518a892f18596c9ac12414cf522c56ead5469eb586233927R62), but after that [it stopped working](https://github.com/stackkit/laravel-google-cloud-tasks-queue/commit/8d6e8b22dc23080be1dc9754373995e67712907e#diff-369ea07f0ba3fd0b518a892f18596c9ac12414cf522c56ead5469eb586233927R106).

The problem: the `$command` is an array, but is treated like an object. I updated the code to treat is as an array and added a test for it.

If you have any feedback please let me know so we can get this bug fixed quickly. (this bug is withholding me from properly using this package)