### PR TITLE
use recomended hash prefix for task name

### DIFF
--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -219,7 +219,7 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
             $this->config['project'],
             $this->config['location'],
             $queueName,
-            $displayName . '-' . $payload['uuid'] . '-' . Carbon::now()->getTimeStampMs(),
+            md5(Carbon::now()->getTimeStampMs()) . '-' .$displayName . '-' . $payload['uuid'], //google suggests non sequential displayNames for performance
         );
     }
 

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -152,7 +152,6 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         $payload = $this->withAttempts($payload);
 
         $task = $this->createTask();
-        $task->setName($this->taskName($queue, $payload));
 
         if (!empty($this->config['app_engine'])) {
             $path = \Safe\parse_url(route('cloud-tasks.handle-task'), PHP_URL_PATH);
@@ -209,29 +208,6 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         }
 
         return $payload;
-    }
-
-    private function taskName(string $queueName, array $payload): string
-    {
-        $displayName = $this->sanitizeTaskName($payload['displayName']);
-
-        return CloudTasksClient::taskName(
-            $this->config['project'],
-            $this->config['location'],
-            $queueName,
-            md5(Carbon::now()->getTimeStampMs()) . '-' .$displayName . '-' . $payload['uuid'], //google suggests non sequential displayNames for performance
-        );
-    }
-
-    private function sanitizeTaskName(string $taskName)
-    {
-        // Remove all characters that are not -, letters, numbers, or whitespace
-        $sanitizedName = preg_replace('![^-\pL\pN\s]+!u', '-', $taskName);
-
-        // Replace all separator characters and whitespace by a -
-        $sanitizedName = preg_replace('![-\s]+!u', '-', $sanitizedName);
-
-        return trim($sanitizedName, '-');
     }
 
     private function withAttempts(array $payload): array

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -495,7 +495,7 @@ class QueueTest extends TestCase
         CloudTasksApi::assertTaskCreated(function (Task $task, string $queueName): bool {
             $uuid = \Safe\json_decode($task->getHttpRequest()->getBody(), true)['uuid'];
 
-            return $task->getName() === 'projects/my-test-project/locations/europe-west6/queues/barbequeue/tasks/Tests-Support-SimpleJob-' . $uuid . '-1685649757000';
+            return $task->getName() === 'projects/my-test-project/locations/europe-west6/queues/barbequeue/tasks/'.md5(1685649757000).'-Tests-Support-SimpleJob-' . $uuid;
         });
     }
 }

--- a/tests/TaskHandlerTest.php
+++ b/tests/TaskHandlerTest.php
@@ -490,12 +490,12 @@ class TaskHandlerTest extends TestCase
         // Assert
         CloudTasksApi::assertCreatedTaskCount(2);
         CloudTasksApi::assertTaskCreated(function (Task $task): bool {
-            [$timestamp] = array_reverse(explode('-', $task->getName()));
-            return $timestamp === '1685035628000';
+            [$timestamp] = explode('-', $task->getName());
+            return $timestamp === md5('1685035628000');
         });
         CloudTasksApi::assertTaskCreated(function (Task $task): bool {
-            [$timestamp] = array_reverse(explode('-', $task->getName()));
-            return $timestamp === '1685035629000';
+            [$timestamp] = explode('-', $task->getName());
+            return $timestamp === md5('1685035629000');
         });
     }
 }


### PR DESCRIPTION
In `google/cloud-tasks/src/V2/Gapic/CloudTasksGapicClient.php` the createTask docs say

```
Explicitly specifying a task ID enables task de-duplication. If a task's ID is identical to that of an existing task or a task that
was deleted or executed recently then the call will fail with [ALREADY_EXISTS][google.rpc.Code.ALREADY_EXISTS]. If the
task's queue was created using Cloud Tasks, then another task with the same name can't be created for ~1hour after the
original task was deleted or executed. If the task's queue was created using queue.yaml or queue.xml, then another task with
the same name can't be created for ~9days after the original task was deleted or executed. Because there is an extra lookup
cost to identify duplicate task names, these [CreateTask][google.cloud.tasks.v2.CloudTasks.CreateTask] calls have
significantly increased latency. Using hashed strings for the task id or for the prefix of the task id is recommended. Choosing
task ids that are sequential or have sequential prefixes, for example using a timestamp, causes an increase in latency and
error rates in all task commands. The infrastructure relies on an approximately uniform distribution of task ids to store and
serve tasks efficiently.
```

I'm interpreting this as meaning that making the md5(timestamp) as the prefix will be a performance increase because google can search for duplicate task names quicker.