### PR TITLE
Add ability to customize `WorkerOptions`

### DIFF
--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -15,6 +15,7 @@ use Google\Cloud\Tasks\V2\Task;
 use Google\Protobuf\Timestamp;
 use Illuminate\Contracts\Queue\Queue as QueueContract;
 use Illuminate\Queue\Queue as LaravelQueue;
+use Illuminate\Queue\WorkerOptions;
 use Illuminate\Support\Str;
 use Stackkit\LaravelGoogleCloudTasksQueue\Events\TaskCreated;
 
@@ -26,6 +27,9 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
     private static ?Closure $handlerUrlCallback = null;
 
     private static ?Closure $taskHeadersCallback = null;
+
+    /** @var (Closure(IncomingTask): WorkerOptions)|null */
+    private static ?Closure $workerOptionsCallback = null;
 
     public function __construct(public array $config, public CloudTasksClient $client, public $dispatchAfterCommit = false)
     {
@@ -50,6 +54,27 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
     public static function forgetTaskHeadersCallback(): void
     {
         self::$taskHeadersCallback = null;
+    }
+
+    /**
+     * @param  Closure(IncomingTask): WorkerOptions  $callback
+     */
+    public static function configureWorkerOptionsUsing(Closure $callback): void
+    {
+        static::$workerOptionsCallback = $callback;
+    }
+
+    /**
+     * @return (Closure(IncomingTask): WorkerOptions)|null
+     */
+    public static function getWorkerOptionsCallback(): ?Closure
+    {
+        return self::$workerOptionsCallback;
+    }
+
+    public static function forgetWorkerOptionsCallback(): void
+    {
+        self::$workerOptionsCallback = null;
     }
 
     /**

--- a/src/TaskHandler.php
+++ b/src/TaskHandler.php
@@ -61,7 +61,7 @@ class TaskHandler
         tap(app('cloud-tasks.worker'), fn (Worker $worker) => $worker->process(
             connectionName: $job->getConnectionName(),
             job: $job,
-            options: $this->getWorkerOptions()
+            options: CloudTasksQueue::getWorkerOptionsCallback() ? (CloudTasksQueue::getWorkerOptionsCallback())($task) : $this->getWorkerOptions()
         ));
     }
 

--- a/tests/Support/FailingJobWithNoMaxTries.php
+++ b/tests/Support/FailingJobWithNoMaxTries.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+class FailingJobWithNoMaxTries extends FailingJob
+{
+    public $tries = null;
+}


### PR DESCRIPTION
We have found ourselves in the need of specifying `maxRetries` and `backoff` globally on a queue basis, similar to how you can do it on Google Cloud Tasks. It makes it more convenient to have these parameters listed in a single place (most likely a config file) than having to implement them in every job and then trying to keep them in sync.

I used a similar approach as it was done in #139 with handler url.
Initially I wanted to use the callback inside `getWorkerOptions()` of `TaskHandler`, but that method has not job or task context to get the queue from. Adding `IncomingTask` argument to the method would introduce a breaking change in case someone has extended `TaskHandler.