### PR TITLE
Explicitly specify job queue

### DIFF
--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -98,6 +98,10 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
      */
     public function push($job, $data = '', $queue = null)
     {
+        if (! ($job instanceof Closure)) {
+            $job->queue = $queue ?? $job->queue ?? $this->config['queue'];
+        }
+
         return $this->enqueueUsing(
             $job,
             $this->createPayload($job, $queue, $data),

--- a/tests/TaskHandlerTest.php
+++ b/tests/TaskHandlerTest.php
@@ -33,13 +33,13 @@ class TaskHandlerTest extends TestCase
         CloudTasksApi::fake();
     }
 
-	#[Override]
-	protected function tearDown(): void
-	{
-		parent::tearDown();
+    #[Override]
+    protected function tearDown(): void
+    {
+        parent::tearDown();
 
-		CloudTasksQueue::forgetWorkerOptionsCallback();
-	}
+        CloudTasksQueue::forgetWorkerOptionsCallback();
+    }
 
     #[Test]
     public function it_can_run_a_task()


### PR DESCRIPTION
# Issue

Take this batch for example:
```php
Bus::batch([new TestBatchedJob()])->onQueue('batch')->dispatch();
```

Running `php artisan queue:work --queue=batch` in a regular Laravel application successfully executes `TestBatchedJob` job on `batch` queue, even if the job has set a different queue, such as `$this->queue = 'default'`.

---

Using the same batch with this package is currently not possible, unless you specifically set the same queue on the job too. Batch jobs do get dispatched to GCT on correct queue (`batch`), but it fails the execution because it cannot pass [existence check on `TaskHandler`](https://github.com/stackkit/laravel-google-cloud-tasks-queue/blob/master/src/TaskHandler.php#L31-L33). That's because it tries to [resolve queue name](https://github.com/stackkit/laravel-google-cloud-tasks-queue/blob/master/src/IncomingTask.php#L46-L52) from serialized payload, but it won't find one and default to `default` queue set in config, unless you specified queue directly on the job.

# Solution

I found out that we could always set the queue on the job instance before dispatching it to GCT. Unfortunately it's not possible to to do that for batched closures, because they are transformed into `CallQueuedClosure` inside `\Illuminate\Queue\Queue::createPayload()` and then immediately serialized.

Only 1 test failed initially with this change and it was because it was expecting `SimpleJob` queue to be `null`, but with this change it is set to default queue. I added couple extra cases to test regular closure dispatch too. . I haven't found any batch tests in this repo, so I'm not sure how to best test batch dispatching to showcase the original issue.