### PR TITLE
the name 'assoc' is wrong, just leave it as true

### DIFF
--- a/src/IncomingTask.php
+++ b/src/IncomingTask.php
@@ -21,7 +21,7 @@ class IncomingTask
     public static function fromJson(string $payload): self
     {
         try {
-            $decode = json_decode($payload, assoc: true);
+            $decode = json_decode($payload, true);
 
             return new self(is_array($decode) ? $decode : []);
         } catch (JsonException) {


### PR DESCRIPTION
The named param is wrong, it points to $assoc which doesnt exist ... you can either use $associative or leave it blank https://www.php.net/manual/en/function.json-decode.php