### PR TITLE
Can configure the Cloud Task dispatch_deadline option. Default is 10 …

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Add a new queue connection to `config/queue.php`
   
   'backoff' => 0,
   'after_commit' => false,
+  // enable this if you want to set a non-default Google Cloud Tasks dispatch timeout
+  //'dispatch_deadline' => 1800, // in seconds
 ],
 ```
 

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -6,6 +6,7 @@ namespace Stackkit\LaravelGoogleCloudTasksQueue;
 
 use Closure;
 use Exception;
+use Google\Protobuf\Duration;
 use Illuminate\Support\Str;
 
 use function Safe\json_decode;
@@ -282,6 +283,10 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
             $token->setServiceAccountEmail($this->config['service_account_email'] ?? '');
             $httpRequest->setOidcToken($token);
             $task->setHttpRequest($httpRequest);
+
+            if (! empty($this->config['dispatch_deadline'])) {
+                $task->setDispatchDeadline((new Duration())->setSeconds($this->config['dispatch_deadline']));
+            }
         }
 
         return $task;

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -566,4 +566,51 @@ class QueueTest extends TestCase
         // Assert
         Event::assertDispatched(fn (JobOutput $event) => $event->output === 'ClosureJob:success');
     }
+
+    #[Test]
+    public function task_has_no_dispatch_deadline_by_default(): void
+    {
+        // Arrange
+        CloudTasksApi::fake();
+
+        // Act
+        $this->dispatch(new SimpleJob());
+
+        // Assert
+        CloudTasksApi::assertTaskCreated(function (Task $task): bool {
+            return $task->getDispatchDeadline() === null;
+        });
+    }
+
+    #[Test]
+    public function task_has_no_dispatch_deadline_if_config_is_empty(): void
+    {
+        // Arrange
+        CloudTasksApi::fake();
+        $this->setConfigValue('dispatch_deadline', null);
+
+        // Act
+        $this->dispatch(new SimpleJob());
+
+        // Assert
+        CloudTasksApi::assertTaskCreated(function (Task $task): bool {
+            return $task->getDispatchDeadline() === null;
+        });
+    }
+
+    #[Test]
+    public function task_has_configured_dispatch_deadline(): void
+    {
+        // Arrange
+        CloudTasksApi::fake();
+        $this->setConfigValue('dispatch_deadline', 1800);
+
+        // Act
+        $this->dispatch(new SimpleJob());
+
+        // Assert
+        CloudTasksApi::assertTaskCreated(function (Task $task): bool {
+            return $task->getDispatchDeadline()->getSeconds() === 1800;
+        });
+    }
 }


### PR DESCRIPTION
…minutes, but some tasks take longer than that.

See this issue: https://github.com/stackkit/laravel-google-cloud-tasks-queue/issues/177