### PR TITLE
Reset job attempts counter when retrying failed jobs via `queue:retry`.

### DIFF
--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -159,6 +159,14 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         $delay = ! empty($options['delay']) ? $options['delay'] : 0;
         $job = $options['job'] ?? null;
 
+        // When no job object is present, this was called by queue:retry.
+        // Reset the attempt counter so the job doesn't immediately exceed max attempts.
+        if ($job === null) {
+            $decoded = (array) json_decode($payload, true);
+            $decoded['internal']['attempts'] = 0;
+            $payload = json_encode($decoded);
+        }
+
         return $this->pushToCloudTasks($queue, $payload, $delay, $job);
     }
 

--- a/src/CloudTasksQueue.php
+++ b/src/CloudTasksQueue.php
@@ -159,14 +159,6 @@ class CloudTasksQueue extends LaravelQueue implements QueueContract
         $delay = ! empty($options['delay']) ? $options['delay'] : 0;
         $job = $options['job'] ?? null;
 
-        // When no job object is present, this was called by queue:retry.
-        // Reset the attempt counter so the job doesn't immediately exceed max attempts.
-        if ($job === null) {
-            $decoded = (array) json_decode($payload, true);
-            $decoded['internal']['attempts'] = 0;
-            $payload = json_encode($decoded);
-        }
-
         return $this->pushToCloudTasks($queue, $payload, $delay, $job);
     }
 

--- a/src/CloudTasksServiceProvider.php
+++ b/src/CloudTasksServiceProvider.php
@@ -89,6 +89,8 @@ class CloudTasksServiceProvider extends LaravelServiceProvider
                 return;
             }
 
+            $event->job->setAttempts(0);
+
             app('queue.failer')->log(
                 $event->job->getConnectionName(),
                 $event->job->getQueue(),

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -24,6 +24,7 @@ use Illuminate\Queue\CallQueuedClosure;
 use Tests\Support\SimpleJobWithTimeout;
 use Tests\Support\JobThatWillBeReleased;
 use Illuminate\Queue\Events\JobProcessed;
+use Tests\Support\FailingJobWithMaxTries;
 use Illuminate\Queue\Events\JobProcessing;
 use Tests\Support\SimpleJobWithDelayProperty;
 use Tests\Support\FailingJobWithExponentialBackoff;
@@ -656,20 +657,17 @@ class QueueTest extends TestCase
         // Arrange
         CloudTasksApi::fake();
 
-        $payload = json_encode([
-            'uuid' => (string) Str::uuid(),
-            'displayName' => SimpleJob::class,
-            'internal' => ['attempts' => 3],
-        ]);
-
-        // Act - simulate queue:retry by calling pushRaw without a 'job' option
-        Queue::connection('my-cloudtasks-connection')->pushRaw($payload, 'barbequeue');
+        // Act
+        $this
+            ->dispatch(new FailingJobWithMaxTries)
+            ->runAndGetReleasedJob()
+            ->runAndGetReleasedJob()
+            ->runAndGetReleasedJob();
 
         // Assert
-        CloudTasksApi::assertTaskCreated(function (Task $task): bool {
-            $decoded = json_decode($task->getHttpRequest()->getBody(), true);
-
-            return $decoded['internal']['attempts'] === 0;
-        });
+        $this->assertDatabaseCount('failed_jobs', 1);
+        $row = DB::table('failed_jobs')->latest('id')->first();
+        $payload = json_decode($row->payload, true);
+        $this->assertSame(0, $payload['internal']['attempts']);
     }
 }

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -649,4 +649,27 @@ class QueueTest extends TestCase
             return $task->getScheduleTime() === null;
         });
     }
+
+    #[Test]
+    public function it_resets_attempts_when_retrying_a_failed_job(): void
+    {
+        // Arrange
+        CloudTasksApi::fake();
+
+        $payload = json_encode([
+            'uuid' => (string) Str::uuid(),
+            'displayName' => SimpleJob::class,
+            'internal' => ['attempts' => 3],
+        ]);
+
+        // Act - simulate queue:retry by calling pushRaw without a 'job' option
+        Queue::connection('my-cloudtasks-connection')->pushRaw($payload, 'barbequeue');
+
+        // Assert
+        CloudTasksApi::assertTaskCreated(function (Task $task): bool {
+            $decoded = json_decode($task->getHttpRequest()->getBody(), true);
+
+            return $decoded['internal']['attempts'] === 0;
+        });
+    }
 }


### PR DESCRIPTION
Hey there

Just found this package yesterday, already migrated one app over and it's doing a wonderful job! ❤️ Thanks!

I ran into this behavior when `artisan queue:retry` is called: it reads the raw payload from `failed_jobs` and creates another task. The number of attempts is saved inside this payload (`internal.attempts`). The stored payload already has attempts at the maximum for the job, so the requeued task immediately throws `MaxAttemptsExceededException` on execution: Making queue:retry effectively "obsolete."

I found that `pushRaw()` is only called without `$options['job']` in the retry case. So this is a bit of a wonky solution to tackle it, especially resetting it to zero... But thought why not share this :)

Cheers